### PR TITLE
Feat/permission based acl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- user's permission evaluation based on user's properties in USER_PROPERTIES_HEADER_KEY request header
+
 ## 0.8.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- user's permission evaluation based on user's properties in USER_PROPERTIES_HEADER_KEY request header
+- user's permissions evaluation based on user's properties in USER_PROPERTIES_HEADER_KEY request header
 
 ## 0.8.1
 

--- a/packages/be-config/package.json
+++ b/packages/be-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mia-platform/be-config",
-  "version": "0.9.0-rc",
+  "version": "0.8.1",
   "private": true,
   "scripts": {
     "coverage": "yarn test --coverage --watchAll=false --collectCoverageFrom=src/**/*.{ts,tsx}",

--- a/packages/be-config/package.json
+++ b/packages/be-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mia-platform/be-config",
-  "version": "0.8.1",
+  "version": "0.9.0-rc",
   "private": true,
   "scripts": {
     "coverage": "yarn test --coverage --watchAll=false --collectCoverageFrom=src/**/*.{ts,tsx}",

--- a/packages/be-config/src/apis/configurationApi.ts
+++ b/packages/be-config/src/apis/configurationApi.ts
@@ -19,6 +19,7 @@ import {DecoratedFastify, Handler} from '@mia-platform/custom-plugin-lib'
 
 import {readValidateConfiguration} from '../utils/configurationManager'
 import {aclExpressionEvaluator} from '../utils/aclExpressionEvaluator'
+import {getPermissions} from '../utils/getPermissions'
 
 const readPluginConfiguration = async(fastifyInstance: DecoratedFastify) => {
   const configurationPath = fastifyInstance.config.MICROLC_CONFIGURATION_PATH as string
@@ -36,10 +37,13 @@ const buildNewConfiguration = (oldConfiguration: Configuration, allowedPlugins: 
 
 export const configurationApiHandlerBuilder: (fastifyInstance: DecoratedFastify) => Promise<Handler<Configuration>> = async(fastifyInstance) => {
   const configuration: Configuration = await readPluginConfiguration(fastifyInstance)
+  const userPropertiesHeader = fastifyInstance.config.USER_PROPERTIES_HEADER_KEY
+
   return (request, reply) => {
     const userGroups = request.getGroups()
-    const allowedPlugins = aclExpressionEvaluator(configuration.plugins || [], userGroups, [])
-    const allowedInternalPlugins = aclExpressionEvaluator(configuration.internalPlugins || [], userGroups, [])
+    const userPermissions = getPermissions(request, userPropertiesHeader)
+    const allowedPlugins = aclExpressionEvaluator(configuration.plugins || [], userGroups, userPermissions)
+    const allowedInternalPlugins = aclExpressionEvaluator(configuration.internalPlugins || [], userGroups, userPermissions)
     const configurationForUser = buildNewConfiguration(configuration, allowedPlugins, allowedInternalPlugins)
     reply.send(configurationForUser)
   }

--- a/packages/be-config/src/apis/configurationApi.ts
+++ b/packages/be-config/src/apis/configurationApi.ts
@@ -38,8 +38,8 @@ export const configurationApiHandlerBuilder: (fastifyInstance: DecoratedFastify)
   const configuration: Configuration = await readPluginConfiguration(fastifyInstance)
   return (request, reply) => {
     const userGroups = request.getGroups()
-    const allowedPlugins = aclExpressionEvaluator(configuration.plugins || [], userGroups)
-    const allowedInternalPlugins = aclExpressionEvaluator(configuration.internalPlugins || [], userGroups)
+    const allowedPlugins = aclExpressionEvaluator(configuration.plugins || [], userGroups, [])
+    const allowedInternalPlugins = aclExpressionEvaluator(configuration.internalPlugins || [], userGroups, [])
     const configurationForUser = buildNewConfiguration(configuration, allowedPlugins, allowedInternalPlugins)
     reply.send(configurationForUser)
   }

--- a/packages/be-config/src/apis/configurationFileApi.ts
+++ b/packages/be-config/src/apis/configurationFileApi.ts
@@ -24,7 +24,7 @@ import {referencesReplacer} from '../utils/referencesReplacer'
 const retrieveJsonConfiguration = async(instanceConfig: any, configurationName: string, userGroups: string[]) => {
   const configurationPath = `${instanceConfig.PLUGINS_CONFIGURATIONS_PATH}/${configurationName}`
   const configurationContent = await readJsonConfigurationFile(configurationPath)
-  const configurationContentFiltered = aclExpressionEvaluator(configurationContent, userGroups)
+  const configurationContentFiltered = aclExpressionEvaluator(configurationContent, userGroups, [])
   return referencesReplacer(configurationContentFiltered)
 }
 

--- a/packages/be-config/src/apis/configurationFileApi.ts
+++ b/packages/be-config/src/apis/configurationFileApi.ts
@@ -20,11 +20,12 @@ import {CONFIGURATION_NAME} from '../constants'
 import {aclExpressionEvaluator} from '../utils/aclExpressionEvaluator'
 import {readJsonConfigurationFile, readRawFile} from '../utils/configurationManager'
 import {referencesReplacer} from '../utils/referencesReplacer'
+import {getPermissions} from '../utils/getPermissions'
 
-const retrieveJsonConfiguration = async(instanceConfig: any, configurationName: string, userGroups: string[]) => {
+const retrieveJsonConfiguration = async(instanceConfig: any, configurationName: string, userGroups: string[], userPermissions: string[]) => {
   const configurationPath = `${instanceConfig.PLUGINS_CONFIGURATIONS_PATH}/${configurationName}`
   const configurationContent = await readJsonConfigurationFile(configurationPath)
-  const configurationContentFiltered = aclExpressionEvaluator(configurationContent, userGroups, [])
+  const configurationContentFiltered = aclExpressionEvaluator(configurationContent, userGroups, userPermissions)
   return referencesReplacer(configurationContentFiltered)
 }
 
@@ -35,12 +36,13 @@ const retrieveRawConfiguration = async(instanceConfig: any, configurationName: s
 
 export const configurationFileApiHandlerBuilder: (fastifyInstance: DecoratedFastify) => Handler<any> = (fastifyInstance) => {
   const instanceConfig: any = fastifyInstance.config
+  const userPropertiesHeader = fastifyInstance.config.USER_PROPERTIES_HEADER_KEY
   return async(request, reply) => {
     if (instanceConfig.PLUGINS_CONFIGURATIONS_PATH) {
       // @ts-ignore
       const configurationName: string = request.params[CONFIGURATION_NAME]
       const retrieveFunction = configurationName.endsWith('.json') ? retrieveJsonConfiguration : retrieveRawConfiguration
-      const fileContent = await retrieveFunction(instanceConfig, configurationName, request.getGroups())
+      const fileContent = await retrieveFunction(instanceConfig, configurationName, request.getGroups(), getPermissions(request, userPropertiesHeader))
       reply.send(fileContent)
     } else {
       reply.status(404).send()

--- a/packages/be-config/src/constants.ts
+++ b/packages/be-config/src/constants.ts
@@ -41,3 +41,9 @@ export const GROUPS_CONFIGURATION = {
     key: 'groups',
   },
 }
+
+export const PERMISSIONS_CONFIGURATION = {
+  function: {
+    key: 'permissions',
+  },
+}

--- a/packages/be-config/src/utils/__tests__/aclExpressionEvaluator.test.ts
+++ b/packages/be-config/src/utils/__tests__/aclExpressionEvaluator.test.ts
@@ -71,12 +71,12 @@ describe('Plugins filter tests', () => {
     expect(pluginsFiltered).toMatchObject([])
   })
 
-  it('Everything is fine with empty plugins and groups list', () => {
+  it('Everything is fine with empty plugins and groups and permissions list', () => {
     const pluginsFiltered = aclExpressionEvaluator([], [], [])
     expect(pluginsFiltered).toMatchObject([])
   })
 
-  it('general object and no groups', () => {
+  it('general object and no groups and permissions', () => {
     const allConfiguration = {
       test: {
         nested: {
@@ -197,6 +197,20 @@ describe('Plugins filter tests', () => {
     }
     const filtered = aclExpressionEvaluator(toFilter, ['doctor'], ['api.users.get', 'api.users.post', 'api.test-crud.all'])
     expect(filtered.plugins.length).toBe(2)
+    expect(filtered.plugins.length).not.toBe(toFilter.plugins.length)
+    expect(filtered).not.toBe(toFilter)
+  })
+
+  it('works with permissions not assigned in aclExpression', () => {
+    const toFilter = {
+      plugins: [
+        {
+          aclExpression: 'permissions.api.test-crud.all || permissions.api.test-crud.get',
+        },
+      ],
+    }
+    const filtered = aclExpressionEvaluator(toFilter, ['doctor'], ['api.users.post'])
+    expect(filtered.plugins.length).toBe(0)
     expect(filtered.plugins.length).not.toBe(toFilter.plugins.length)
     expect(filtered).not.toBe(toFilter)
   })

--- a/packages/be-config/src/utils/__tests__/aclExpressionEvaluator.test.ts
+++ b/packages/be-config/src/utils/__tests__/aclExpressionEvaluator.test.ts
@@ -182,6 +182,9 @@ describe('Plugins filter tests', () => {
     const toFilter = {
       plugins: [
         {
+          aclExpression: 'permissions.api.test-crud.all || permissions.api.test-crud.get',
+        },
+        {
           aclExpression: 'groups.superadmin || groups.admin || groups.secretary',
         },
         {
@@ -189,9 +192,6 @@ describe('Plugins filter tests', () => {
         },
         {
           aclExpression: 'groups.superadmin || groups.admin',
-        },
-        {
-          aclExpression: 'permissions.api.test_crud.all',
         },
       ],
     }

--- a/packages/be-config/src/utils/aclExpressionEvaluator.ts
+++ b/packages/be-config/src/utils/aclExpressionEvaluator.ts
@@ -54,15 +54,16 @@ const createUserPermissionsNestedObject = (originalObject: any, permissionPaths:
 const userPermissionsObjectBuilder = (userPermissions: string[]) => {
   const userPermissionObject: UserPermissionsObject = {}
   for (let i = 0; i < userPermissions.length; i++) {
-    const permissions = userPermissions[i].replace('-', '_').split('.')
+    const permissions = userPermissions[i].split('.')
     createUserPermissionsNestedObject(userPermissionObject, permissions)
   }
   return userPermissionObject
 }
 
 const buildPluginFunction = (plugin: FilterableObject) => {
+  const bracketsNotationExpression = plugin.aclExpression.replace(/\.(.+?)(?=\.|$| )/g, (_, string) => `['${string}']`)
   // eslint-disable-next-line no-new-func
-  return new Function(GROUPS_CONFIGURATION.function.key, PERMISSIONS_CONFIGURATION.function.key, `return !!(${plugin.aclExpression})`)
+  return new Function(GROUPS_CONFIGURATION.function.key, PERMISSIONS_CONFIGURATION.function.key, `return !!(${bracketsNotationExpression})`)
 }
 
 const evaluatePluginExpression = (userGroupsObject: UserGroupsObject, userPermissionsObject: UserPermissionsObject) => {

--- a/packages/be-config/src/utils/aclExpressionEvaluator.ts
+++ b/packages/be-config/src/utils/aclExpressionEvaluator.ts
@@ -61,7 +61,7 @@ const userPermissionsObjectBuilder = (userPermissions: string[]) => {
 }
 
 const buildPluginFunction = (plugin: FilterableObject) => {
-  const bracketsNotationExpression = plugin.aclExpression.replace(/\.(.+?)(?=\.|$| )/g, (_, string) => `['${string}']`)
+  const bracketsNotationExpression = plugin.aclExpression.replace(/\.(.+?)(?=\.|$| )/g, (_, string) => `?.['${string}']`)
   // eslint-disable-next-line no-new-func
   return new Function(GROUPS_CONFIGURATION.function.key, PERMISSIONS_CONFIGURATION.function.key, `return !!(${bracketsNotationExpression})`)
 }

--- a/packages/be-config/src/utils/aclExpressionEvaluator.ts
+++ b/packages/be-config/src/utils/aclExpressionEvaluator.ts
@@ -61,9 +61,10 @@ const userPermissionsObjectBuilder = (userPermissions: string[]) => {
 }
 
 const buildPluginFunction = (plugin: FilterableObject) => {
-  const bracketsNotationExpression = plugin.aclExpression.replace(/\.(.+?)(?=\.|$| )/g, (_, string) => `?.['${string}']`)
+  const bracketsNotationExpression = plugin.aclExpression.replace(/\.(.+?)(?=\.|$| |\))/g, (_, string) => `?.['${string}']`)
+  const booleanEvaluationExpression = bracketsNotationExpression.replace(/'](?=]|$| )/g, `'] === true`)
   // eslint-disable-next-line no-new-func
-  return new Function(GROUPS_CONFIGURATION.function.key, PERMISSIONS_CONFIGURATION.function.key, `return !!(${bracketsNotationExpression})`)
+  return new Function(GROUPS_CONFIGURATION.function.key, PERMISSIONS_CONFIGURATION.function.key, `return !!(${booleanEvaluationExpression})`)
 }
 
 const evaluatePluginExpression = (userGroupsObject: UserGroupsObject, userPermissionsObject: UserPermissionsObject) => {

--- a/packages/be-config/src/utils/aclExpressionEvaluator.ts
+++ b/packages/be-config/src/utils/aclExpressionEvaluator.ts
@@ -16,10 +16,14 @@
 import {JSONPath} from 'jsonpath-plus'
 import {applyOperation, Operation, deepClone} from 'fast-json-patch'
 
-import {GROUPS_CONFIGURATION} from '../constants'
+import {GROUPS_CONFIGURATION, PERMISSIONS_CONFIGURATION} from '../constants'
 
 type UserGroupsObject = {
   [key: string]: boolean
+}
+
+type UserPermissionsObject = {
+  [key: string]: boolean | object
 }
 
 type FilterableObject = {
@@ -34,15 +38,37 @@ const userGroupsObjectBuilder = (userGroups: string[]) => {
   return userGroupsObject
 }
 
-const buildPluginFunction = (plugin: FilterableObject) => {
-  // eslint-disable-next-line no-new-func
-  return new Function(GROUPS_CONFIGURATION.function.key, `return !!(${plugin.aclExpression})`)
+const createUserPermissionsNestedObject = (originalObject: any, permissionPaths: string[]) => {
+  for (let i = 0; i < permissionPaths.length; i++) {
+    // eslint-disable-next-line no-param-reassign, no-multi-assign
+    if (i < permissionPaths.length - 1) {
+      // eslint-disable-next-line no-param-reassign, no-multi-assign
+      originalObject = originalObject[permissionPaths[i]] = originalObject[permissionPaths[i]] || {}
+    } else {
+      // eslint-disable-next-line no-multi-assign, no-param-reassign
+      originalObject = originalObject[permissionPaths[i]] = true
+    }
+  }
 }
 
-const evaluatePluginExpression = (userGroupsObject: UserGroupsObject) => {
+const userPermissionsObjectBuilder = (userPermissions: string[]) => {
+  const userPermissionObject: UserPermissionsObject = {}
+  for (let i = 0; i < userPermissions.length; i++) {
+    const permissions = userPermissions[i].replace('-', '_').split('.')
+    createUserPermissionsNestedObject(userPermissionObject, permissions)
+  }
+  return userPermissionObject
+}
+
+const buildPluginFunction = (plugin: FilterableObject) => {
+  // eslint-disable-next-line no-new-func
+  return new Function(GROUPS_CONFIGURATION.function.key, PERMISSIONS_CONFIGURATION.function.key, `return !!(${plugin.aclExpression})`)
+}
+
+const evaluatePluginExpression = (userGroupsObject: UserGroupsObject, userPermissionsObject: UserPermissionsObject) => {
   return (plugin: FilterableObject) => {
     const expressionEvaluationFunction = buildPluginFunction(plugin)
-    return expressionEvaluationFunction(userGroupsObject)
+    return expressionEvaluationFunction(userGroupsObject, userPermissionsObject)
   }
 }
 
@@ -57,10 +83,11 @@ const patchCreator = (valueToAvoid: string): Operation => ({
   path: valueToAvoid,
 })
 
-export const aclExpressionEvaluator = (jsonToFilter: any, userGroups: string[]) => {
+export const aclExpressionEvaluator = (jsonToFilter: any, userGroups: string[], userPermissions: string[]) => {
   const clonedJsonToFilter = deepClone(jsonToFilter)
   const userGroupsObject = userGroupsObjectBuilder(userGroups)
-  const expressionEvaluator = evaluatePluginExpression(userGroupsObject)
+  const userPermissionsObject = userPermissionsObjectBuilder(userPermissions)
+  const expressionEvaluator = evaluatePluginExpression(userGroupsObject, userPermissionsObject)
   const valuesToAvoid: string[] = []
   const pathCallback = jsonPathCallback(valuesToAvoid, expressionEvaluator)
   do {

--- a/packages/be-config/src/utils/getPermissions.ts
+++ b/packages/be-config/src/utils/getPermissions.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Mia srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const getPermissions = (request: any, userPropertiesHeader?: string): string[] => {
+  if (userPropertiesHeader) {
+    const {headers} = request
+    const userProperties: string = headers[userPropertiesHeader] || '{}'
+    const {permissions = []} = JSON.parse(userProperties)
+    return permissions
+  }
+  return []
+}


### PR DESCRIPTION
Hi, 

the aim of this PR is to add user's `permissions` evaluation to the aclExpression alongside the user's `groups`.
Using the USER_PROPERTIES_HEADER_KEY env variable, the backend will retrieve from a stringified json object the user's `permissions` string array if available.

Considering a user with this permissions:

`"permissions": ['api.users.get]`

In the `aclExpression` the it's possible to add:

`"aclExpression":  "permissions.api.users.get"`

The permissions are optional and the feature  does not introduce breaking changes.
