### PR TITLE
Iconic/default icon props

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,19 @@ Remind to build dependencies as prompted [before](#build) and then run:
 yarn l storybook
 ```
 
+A local playground is also available. Run:
+
+```shell
+yarn playground
+```
+
+to start the playground, and:
+
+```shell
+yarn playground-stop
+```
+to stop it.
+
 ## Contributing
 
 We are thankful for any contributions from the community, read our [contributing guide](./CONTRIBUTING.md) to learn

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "yarn workspaces foreach --all run test",
     "coverage": "yarn node ./scripts/repo-scripts.mjs coverage",
     "playground": "yarn node playground.mjs",
+    "playground-stop": "docker-compose --file playground/docker-compose.yml down",
     "serve": " python3 ./scripts/server.py -p 8000 -d .",
     "postinstall": "husky install"
   },

--- a/packages/iconic/src/useIcon/index.ts
+++ b/packages/iconic/src/useIcon/index.ts
@@ -41,7 +41,7 @@ function iconSvgCompose({ attrs, children = [] }: SvgComponent, { ref, ...props 
 export function useIcon(
   selector: string, resource: ResourceObject, errorHandler?: (msg: string) => void
 ): LazyExoticComponent<ForwardRefExoticComponent<SVGProps & RefAttributes<HTMLElement>>> {
-  const defaultReturnValue = { default: forwardRef((props: SVGProps, ref: ForwardedRef<HTMLElement>) => createElement('svg', { props, ref })) }
+  const defaultReturnValue = { default: forwardRef((props: SVGProps, ref: ForwardedRef<HTMLElement>) => createElement('svg', { ...props, ref })) }
   return lazy(() => importIcon(selector, resource)
     .then((icon) => (
       { default: forwardRef((props: SVGProps, ref: ForwardedRef<HTMLElement>) => iconSvgCompose(icon as SvgComponent, { ...props, ref })) }

--- a/packages/layout/src/web-components/mlc-layout/stories/mlc-layout.stories.ts
+++ b/packages/layout/src/web-components/mlc-layout/stories/mlc-layout.stories.ts
@@ -226,3 +226,22 @@ CustomLocale.args = {
   mode: 'fixedSideBar',
   userMenu,
 }
+
+export const BrokenIcon = Template.bind({}) as Story<MlcLayout>
+BrokenIcon.storyName = 'With unresolved icon'
+BrokenIcon.args = {
+  helpMenu: { helpHref: 'https://docs.mia-platform.eu/' },
+  logo,
+  menuItems: [
+    ...menuItems,
+    {
+      icon: { library: '@ant-design/icons-svg', selector: 'unk' },
+      id: 'broken_icon',
+      label: { en: 'Unresolved icon', it: 'Icona non risolta' },
+      type: 'application',
+    },
+  ],
+  microlcApi,
+  mode: 'fixedSideBar',
+  userMenu,
+}


### PR DESCRIPTION
Changes:
  - in layout component, in case the given icon is not resolved, the default `svg` element is created with correct props
  - README.md file includes information on how to start/stop the playground