### PR TITLE
layout sidebar accepts multiple applications per item

### DIFF
--- a/packages/layout/src/react-components/SideBar/SideBar.tsx
+++ b/packages/layout/src/react-components/SideBar/SideBar.tsx
@@ -94,6 +94,12 @@ export const SideBar: React.FC<SideBarProps> = ({
         getPopupContainer={getPopupContainer}
         items={antMenuItems}
         mode='inline'
+        onClick={(info) => {
+          // kick in only when we attempt to move on a subset of selected keys. Won't trump on `onSelect`
+          if (selectedKeys && selectedKeys.findIndex((selectedKey) => selectedKey === info.key) > 0) {
+            onSelect?.({ ...info, key: selectedKeys[0], selectedKeys })
+          }
+        }}
         onSelect={onSelect}
         selectedKeys={selectedKeys}
       />

--- a/packages/layout/src/web-components/mlc-layout/lib/utils.ts
+++ b/packages/layout/src/web-components/mlc-layout/lib/utils.ts
@@ -25,8 +25,8 @@ export const findMenuItemById = (
   id: string
 ): Partial<MenuItem> | undefined => {
   for (const menuItem of menuItems) {
-    const { alsoOn = [] } = menuItem as ApplicationMenuItem
-    if (menuItem.id === id || alsoOn.includes(id)) { return menuItem }
+    const { selectedAlsoOn = [] } = menuItem as ApplicationMenuItem
+    if (menuItem.id === id || selectedAlsoOn.includes(id)) { return menuItem }
 
     if ('children' in menuItem) {
       const foundInChildren = findMenuItemById(menuItem.children ?? [], id)

--- a/packages/layout/src/web-components/mlc-layout/lib/utils.ts
+++ b/packages/layout/src/web-components/mlc-layout/lib/utils.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import type { MenuItem } from '../types'
+import type { GroupMenuItem, MenuItem } from '../types'
 
 export enum Theme {
   DARK = 'dark',
@@ -25,7 +25,8 @@ export const findMenuItemById = (
   id: string
 ): Partial<MenuItem> | undefined => {
   for (const menuItem of menuItems) {
-    if (menuItem.id === id) { return menuItem }
+    const { alsoOn = [] } = menuItem as GroupMenuItem
+    if (menuItem.id === id || alsoOn.includes(id)) { return menuItem }
 
     if ('children' in menuItem) {
       const foundInChildren = findMenuItemById(menuItem.children ?? [], id)

--- a/packages/layout/src/web-components/mlc-layout/lib/utils.ts
+++ b/packages/layout/src/web-components/mlc-layout/lib/utils.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import type { ApplicationMenuItem, GroupMenuItem, MenuItem } from '../types'
+import type { ApplicationMenuItem, MenuItem } from '../types'
 
 export enum Theme {
   DARK = 'dark',
@@ -25,7 +25,7 @@ export const findMenuItemById = (
   id: string
 ): Partial<MenuItem> | undefined => {
   for (const menuItem of menuItems) {
-    const { alsoOn = [] } = menuItem as GroupMenuItem | ApplicationMenuItem
+    const { alsoOn = [] } = menuItem as ApplicationMenuItem
     if (menuItem.id === id || alsoOn.includes(id)) { return menuItem }
 
     if ('children' in menuItem) {

--- a/packages/layout/src/web-components/mlc-layout/lib/utils.ts
+++ b/packages/layout/src/web-components/mlc-layout/lib/utils.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import type { GroupMenuItem, MenuItem } from '../types'
+import type { ApplicationMenuItem, GroupMenuItem, MenuItem } from '../types'
 
 export enum Theme {
   DARK = 'dark',
@@ -25,7 +25,7 @@ export const findMenuItemById = (
   id: string
 ): Partial<MenuItem> | undefined => {
   for (const menuItem of menuItems) {
-    const { alsoOn = [] } = menuItem as GroupMenuItem
+    const { alsoOn = [] } = menuItem as GroupMenuItem | ApplicationMenuItem
     if (menuItem.id === id || alsoOn.includes(id)) { return menuItem }
 
     if ('children' in menuItem) {

--- a/packages/layout/src/web-components/mlc-layout/mlc-layout.lib.ts
+++ b/packages/layout/src/web-components/mlc-layout/mlc-layout.lib.ts
@@ -78,6 +78,14 @@ function onSelect(this: MlcLayout, id: string) {
   }
 }
 
+export function updateSelectedKeys(this: MlcLayout, currApplicationId: string | undefined): void {
+  this._selectedKeys = currApplicationId ? [currApplicationId] : []
+  if (currApplicationId) {
+    const { id } = findMenuItemById(this.menuItems ?? [], currApplicationId) ?? {}
+    id !== undefined && this._selectedKeys.push(id)
+  }
+}
+
 async function logout(this: MlcLayout) {
   const { logout: conf } = this.userMenu ?? {}
 

--- a/packages/layout/src/web-components/mlc-layout/mlc-layout.ts
+++ b/packages/layout/src/web-components/mlc-layout/mlc-layout.ts
@@ -26,7 +26,7 @@ import { error } from '../commons/logger'
 import { getFromLocalStorage } from './lib/local-storage'
 import { DEFAULT_LANGUAGE } from './lib/translation-loader'
 import { Theme } from './lib/utils'
-import { createProps, loadLocale, retrieveUser } from './mlc-layout.lib'
+import { createProps, loadLocale, retrieveUser, updateSelectedKeys } from './mlc-layout.lib'
 import type { MlcApi, User, Head, HelpMenu, Logo, MenuItem, Mode, UserMenu } from './types'
 
 export class MlcLayout extends MlcComponent<WrapperProps> {
@@ -70,7 +70,7 @@ export class MlcLayout extends MlcComponent<WrapperProps> {
 
     if (this._wasDisconnected) {
       this._currentApplicationSub = this.microlcApi?.currentApplication$
-        ?.subscribe(currApplicationId => { if (currApplicationId) { this._selectedKeys = [currApplicationId] } })
+        ?.subscribe(updateSelectedKeys.bind(this))
     }
 
     this._wasDisconnected = false
@@ -93,7 +93,7 @@ export class MlcLayout extends MlcComponent<WrapperProps> {
     retrieveUser.call(this).catch(error)
 
     this._currentApplicationSub = this.microlcApi?.currentApplication$
-      ?.subscribe(currApplicationId => { this._selectedKeys = currApplicationId ? [currApplicationId] : [] })
+      ?.subscribe(updateSelectedKeys.bind(this))
 
     this._sideBarCollapsed = getFromLocalStorage('@microlc:fixedSidebarState') === 'collapsed'
     this._theme = getFromLocalStorage('@microlc:currentTheme') ?? Theme.LIGHT

--- a/packages/layout/src/web-components/mlc-layout/types.ts
+++ b/packages/layout/src/web-components/mlc-layout/types.ts
@@ -70,14 +70,14 @@ export interface HrefMenuItem {
 }
 
 export interface ApplicationMenuItem {
-  alsoOn?: string[]
-
   icon?: Icon
 
   /** Unique identifier of the corresponding micro-lc application  */
   id: string
 
   label?: LocalizedText
+
+  selectedAlsoOn?: string[]
 
   /** Type of the item: micro-lc application */
   type: 'application'

--- a/packages/layout/src/web-components/mlc-layout/types.ts
+++ b/packages/layout/src/web-components/mlc-layout/types.ts
@@ -98,8 +98,6 @@ export interface CategoryMenuItem {
 }
 
 export interface GroupMenuItem {
-  alsoOn?: string[]
-
   children?: MenuItem[]
 
   /** Unique identifier of the group */

--- a/packages/layout/src/web-components/mlc-layout/types.ts
+++ b/packages/layout/src/web-components/mlc-layout/types.ts
@@ -96,6 +96,8 @@ export interface CategoryMenuItem {
 }
 
 export interface GroupMenuItem {
+  alsoOn?: string[]
+
   children?: MenuItem[]
 
   /** Unique identifier of the group */

--- a/packages/layout/src/web-components/mlc-layout/types.ts
+++ b/packages/layout/src/web-components/mlc-layout/types.ts
@@ -70,6 +70,8 @@ export interface HrefMenuItem {
 }
 
 export interface ApplicationMenuItem {
+  alsoOn?: string[]
+
   icon?: Icon
 
   /** Unique identifier of the corresponding micro-lc application  */

--- a/packages/orchestrator/CHANGELOG.md
+++ b/packages/orchestrator/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - url pattern matching extended to parametric values
+- layout sidebar accepts multiple applications per item to mock a SPA folder structure
 
 ### Versioning
 

--- a/playground/backoffice/config.json
+++ b/playground/backoffice/config.json
@@ -85,6 +85,12 @@
             {
               "children": [
                 {
+                  "id": "plain",
+                  "alsoOn": ["plain_details"],
+                  "label": "Inline",
+                  "type": "application"
+                },
+                {
                   "id": "composer_new",
                   "label": "Composer V2",
                   "type": "application"
@@ -161,6 +167,16 @@
           "properties": { "textContent": "Ciao Main" }
         }
       }
+    },
+    "plain": {
+      "integrationMode": "compose",
+      "route": "./ingredients/",
+      "config": {"content": {"tag": "strong", "content": "Home 🏠"}}
+    },
+    "plain_details": {
+      "integrationMode": "compose",
+      "route": "./ingredients/details/",
+      "config": {"content": {"tag": "div", "content": "Hello 👋"}}
     },
     "composer_new": {
       "integrationMode": "compose",

--- a/playground/backoffice/config.json
+++ b/playground/backoffice/config.json
@@ -86,7 +86,7 @@
               "children": [
                 {
                   "id": "plain",
-                  "alsoOn": ["plain_details"],
+                  "alsoOn": ["plain_details", "plain_about"],
                   "label": "Inline",
                   "type": "application"
                 },
@@ -177,6 +177,11 @@
       "integrationMode": "compose",
       "route": "./ingredients/details/",
       "config": {"content": {"tag": "div", "content": "Hello 👋"}}
+    },
+    "plain_about": {
+      "integrationMode": "compose",
+      "route": "./ingredients/about/",
+      "config": {"content": {"tag": "div", "content": "About 📓"}}
     },
     "composer_new": {
       "integrationMode": "compose",

--- a/playground/backoffice/config.json
+++ b/playground/backoffice/config.json
@@ -86,7 +86,7 @@
               "children": [
                 {
                   "id": "plain",
-                  "alsoOn": ["plain_details", "plain_about"],
+                  "selectedAlsoOn": ["plain_details", "plain_about"],
                   "label": "Inline",
                   "type": "application"
                 },


### PR DESCRIPTION
app id --> main selection on menu item
`alsoOn` is an optional key which takes an array of strings identifying the subapplications

moving to subapplication leaves the menu item selected

when clicking the menu item while viewing a subapplication, `mlc-layout` requests the main app id