### PR TITLE
Fix manifest authentication issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Fixed manifest authentication issue, which by design does not send credentials
+
 ## [1.0.0] 2022-11-03
 
 ## [0.9.0]

--- a/packages/fe-container/public/index.html
+++ b/packages/fe-container/public/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="micro-lc"/>
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials"/>
     <title>micro-lc</title>
   </head>
   <body>


### PR DESCRIPTION
Copy of the previous PR [#562](https://github.com/micro-lc/micro-lc/pull/562), that was closed when i realigned the forked branches.  

This Pull Request wants to fix the issue with the manifest request authentication.
The reason is that the browser does not seem to send credential-headers or cookies for 'rel=manifest' attributes on the link-tag, even for same origin requests.
This means that, if the site is under authentication, the server responds with a 401 Unauthorized.
The solution is to add the attribute crossorigin='use-credentials' to the manifest-link-tag.

From [developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#example_web_manifest_with_credentials):

> The use-credentials value must be used when fetching a [manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) that requires credentials, even if the file is from the same origin.

For more on why this is needed on rel="manifest" see https://github.com/w3c/manifest/issues/535#issuecomment-435739223.