### PR TITLE
fix weird qiankun behavior on html + script on parcels

### DIFF
--- a/packages/orchestrator/CHANGELOG.md
+++ b/packages/orchestrator/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `parcel` application can be set using the `{"html": "<path>"}` construct
+
 ## [2.0.6] - 2023-03-28
 
 ### Fixed

--- a/packages/orchestrator/index.html
+++ b/packages/orchestrator/index.html
@@ -24,6 +24,14 @@
     const _ = document.querySelector('micro-lc')
     _.config = {
       "applications": {
+        "react": {
+          "integrationMode": "parcel",
+          "route": "/react/",
+          entry: {
+            html: 'https://micro-lc.io/applications/react-browser-router/',
+          },
+          injectBase: true
+        },
         "about": {
           "config": {
             "content": {
@@ -85,6 +93,15 @@
                 "url": "https://avatars.githubusercontent.com/u/92730708?s=200&v=4"
               },
               "menuItems": [
+              {
+                  "icon": {
+                    "library": "@ant-design/icons-svg",
+                    "selector": "AppleOutlined"
+                  },
+                  "id": "react",
+                  "label": "React",
+                  "type": "application"
+                },
                 {
                   "icon": {
                     "library": "@ant-design/icons-svg",

--- a/packages/orchestrator/src/web-component/lib/update.ts
+++ b/packages/orchestrator/src/web-component/lib/update.ts
@@ -15,7 +15,14 @@
 */
 import type { ComposerOptions, ComposerApi } from '@micro-lc/composer'
 import { premount, createComposerContext } from '@micro-lc/composer'
-import type { Application, Config, Content, GlobalImportMap, PluginConfiguration } from '@micro-lc/interfaces/v2'
+import type {
+  Application,
+  Config,
+  Content,
+  GlobalImportMap,
+  PluginConfiguration,
+  ParcelApplication,
+} from '@micro-lc/interfaces/v2'
 import type { Entry } from 'qiankun'
 import type { Observable } from 'rxjs'
 import { take } from 'rxjs'
@@ -175,6 +182,24 @@ const getExtraIFrameAttributes = (app: {attributes?: Record<string, string>; src
   return extraIframeAttributes
 }
 
+const getParcelEntry = ({ entry }: ParcelApplication): Entry => {
+  if (typeof entry === 'string') {
+    return entry
+  }
+
+  const scripts = toArray(entry.scripts ?? [])
+  const styles = toArray(entry.styles ?? [])
+  if (typeof entry.html === 'string' && scripts.length === 0) {
+    return entry.html
+  }
+
+  return {
+    ...entry,
+    scripts,
+    styles,
+  }
+}
+
 export async function updateApplications<T extends BaseExtension>(this: Microlc<T>): Promise<void> {
   const {
     _config: {
@@ -248,11 +273,7 @@ export async function updateApplications<T extends BaseExtension>(this: Microlc<
     case 'parcel':
     default:
       injectBase = app.injectBase
-      entry = typeof app.entry === 'string' ? app.entry : {
-        html: app.entry.html,
-        scripts: toArray(app.entry.scripts) as string[],
-        styles: toArray(app.entry.styles ?? []),
-      }
+      entry = getParcelEntry(app)
       properties = app.properties
       break
     }

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -164,3 +164,28 @@ test(`
   await page.evaluate((microlc) => microlc.getApi().router.goToApplication('react'), microlcHandle)
   await expect(page.getByRole('link', { name: 'Go To About Page' })).toBeVisible()
 })
+
+test(`
+  [config injection]
+  parcel config as {"html": "<path>"}
+`, async ({ page }) => {
+  await goto(page, {
+    applications: {
+      react: {
+        entry: { html: 'https://micro-lc.io/applications/react-browser-router/' },
+        injectBase: true,
+        integrationMode: 'parcel',
+        route: './react/',
+      },
+    },
+    settings: {
+      defaultUrl: './react/',
+    },
+    version: 2,
+  })
+
+  const microlcHandle = await page.evaluateHandle<Microlc>('document.querySelector(\'micro-lc\')')
+
+  await page.evaluate((microlc) => microlc.getApi().router.goToApplication('react'), microlcHandle)
+  await expect(page.getByRole('link', { name: 'Go To About Page' })).toBeVisible()
+})


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

`parcel` application included as

```json
{
  "html": "/index.html"
}
```

was not properly parsed. An undefined `scripts` field needed to be removed. When `scripts` field is an empty array only the `html` field must be passed, as string, to `qiankun`


## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [x] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->
