### PR TITLE
fix: error pages default vs custom

### DIFF
--- a/packages/orchestrator/CHANGELOG.md
+++ b/packages/orchestrator/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- error page customization does not override all error codes defaults
+
 ## [2.0.7] - 2023-04-03
 
 ### Fixed

--- a/packages/orchestrator/src/config.ts
+++ b/packages/orchestrator/src/config.ts
@@ -107,11 +107,11 @@ export function mergeConfig(document: Document, input: Config): CompleteConfig {
     settings: {
       '4xx': {
         ...def.settings['4xx'],
-        ...input.settings?.['4xx'] 
+        ...input.settings?.['4xx'],
       },
       '5xx': {
         ...def.settings['5xx'],
-        ...input.settings?.['5xx'] 
+        ...input.settings?.['5xx'],
       },
       composerUri: input.settings?.composerUri ?? def.settings.composerUri,
       defaultUrl,

--- a/packages/orchestrator/src/config.ts
+++ b/packages/orchestrator/src/config.ts
@@ -105,8 +105,14 @@ export function mergeConfig(document: Document, input: Config): CompleteConfig {
       content: input.layout?.content ?? def.layout.content,
     },
     settings: {
-      '4xx': input.settings?.['4xx'] ?? def.settings['4xx'],
-      '5xx': input.settings?.['5xx'] ?? def.settings['5xx'],
+      '4xx': {
+        ...def.settings['4xx'],
+        ...input.settings?.['4xx'] 
+      },
+      '5xx': {
+        ...def.settings['5xx'],
+        ...input.settings?.['5xx'] 
+      },
       composerUri: input.settings?.composerUri ?? def.settings.composerUri,
       defaultUrl,
       mountPoint: input.settings?.mountPoint ?? def.settings.mountPoint,

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -201,9 +201,9 @@ test(`
         '4xx': {
           400: {
             integrationMode: 'iframe',
-            src: 'https://example.com'
-          }
-        }
+            src: 'https://example.com',
+          },
+        },
       },
     },
     version: 2,

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -189,3 +189,25 @@ test(`
   await page.evaluate((microlc) => microlc.getApi().router.goToApplication('react'), microlcHandle)
   await expect(page.getByRole('link', { name: 'Go To About Page' })).toBeVisible()
 })
+
+test(`
+  [config injection]
+  error page customization should not override all defaults
+`, async ({ page }) => {
+  await goto(page, {
+    settings: {
+      defaultUrl: '/home',
+      errorPages: {
+        '4xx': {
+          400: {
+            integrationMode: 'iframe',
+            src: 'https://example.com'
+          }
+        }
+      },
+    },
+    version: 2,
+  })
+
+  await expect(page.locator('svg')).toBeVisible()
+})


### PR DESCRIPTION
customize an error page must not override all defaults

<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- 
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->

When configuring error pages, setting a custom error page, such as 401, should not override 404 default, leaving the
no application found case uncovered

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [x] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Update relative `packages/<package>/CHANGELOG.md`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->
