### PR TITLE
bugfix: routing on parcel applications

### DIFF
--- a/packages/orchestrator/CHANGELOG.md
+++ b/packages/orchestrator/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `rxjs` bumped to `7.8.1`
 - `es-module-shims` bumped to `1.7.2`
 
+### Fixed
+
+- routing towards a `parcel` application which is registered as `/app/` takes the precedence when calling the URL `/app`
+- public assets on a `parcel` application are served on a path which ends by a trailing slash
+- removed `console.log` statements
+
 ## [2.0.9] - 2023-04-20
 
 ### Added

--- a/packages/orchestrator/src/web-component/lib/handler.ts
+++ b/packages/orchestrator/src/web-component/lib/handler.ts
@@ -80,5 +80,5 @@ export function postProcessTemplate(tplResult: TemplateResult, opts: PostProcess
 export const getPublicPath = (entry: Entry): string => {
   const path = (typeof entry === 'string' ? entry : (entry.html ?? ''))
   const { origin, pathname } = new URL(path, window.document.baseURI)
-  return `${origin}${pathname}`
+  return `${origin}${pathname}`.replace(/\/?([^/]+)$/, '/')
 }

--- a/playground/backoffice/config.json
+++ b/playground/backoffice/config.json
@@ -152,8 +152,10 @@
     "react": {
       "integrationMode": "parcel",
       "injectBase": true,
-      "route": "./:app/react/",
-      "entry": "http://localhost:8003/"
+      "route": "./react/",
+      "entry": {
+        "html": "https://raw.githubusercontent.com/micro-lc/micro-lc.github.io/gh-pages/applications/react-browser-router/index.html"
+      }
     },
     "main2": {
       "integrationMode": "compose",

--- a/playground/backoffice/index.html
+++ b/playground/backoffice/index.html
@@ -7,11 +7,7 @@
   <meta http-equiv="Content-Security-Policy" content="
     default-src 'self' https: http:;
     script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: data: https://cdn.jsdelivr.net/npm/;
-    connect-src 'self' data:
-      http://localhost:8003/
-      https://micro-lc.io/
-      https://cdn.jsdelivr.net/npm/
-      https://esm.sh/;
+    connect-src 'self' data: https:;
     object-src 'none';
     style-src 'self' 'unsafe-inline';
     img-src 'self' data: https: http:;

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -32,6 +32,17 @@ test('base tag => on `injectBase` href base attribute must be computed according
   await expect(page.getByText('About')).toBeVisible()
 })
 
+test('trailing slash should win on exact on route when trailing slash route is longer', async ({ page }) => {
+  await page.goto('http://localhost:3000/__reverse/react')
+
+  await expect(page.getByText('Go to about page')).toBeVisible()
+  expect(page.url()).toEqual('http://localhost:3000/__reverse/react/')
+
+  await page.getByRole('link', { name: 'Go To About Page' }).click()
+
+  await expect(page.getByText('About')).toBeVisible()
+})
+
 test(`
   [react/angular routing]
   react and angular apps should move to their relative /about page and back

--- a/tests/server.ts
+++ b/tests/server.ts
@@ -1,12 +1,19 @@
-/* eslint-disable no-sync */
+
 import fs from 'fs'
 import path from 'path'
 
+import type { Response } from 'express'
 import express from 'express'
 
 const port = 3000
 
 const app = express()
+
+const notFound = (res: Response) => {
+  res.statusCode = 404
+  res.setHeader('Content-Type', 'application/json')
+  res.send({ error: 'Not Found', message: 'Not Found', status: 404 })
+}
 
 app.use('/playground', express.static('playground'))
 app.use('/packages', express.static('packages'))
@@ -15,36 +22,20 @@ app.use('/dev/*', express.static('tests/dev'))
 app.use('/pages/*', express.static('tests/pages'))
 app.use('/applications/*', express.static('tests/applications'))
 
-app.use('/__reverse/*', (req, res, next) => {
-  console.log(req.url)
-  const { url } = req
-  const baseIndex = '/__reverse/index.html'
-  const upperIndex = url.endsWith('/') ? path.join(url, 'index.html') : url.replace(/\/([^/]+)$/, '/index.html')
-  const entry = fs.lstatSync(path.join(__dirname, url), { throwIfNoEntry: false })
-  if (entry) {
-    req.url = upperIndex
-    express.static('/__reverse')(req, res, next)
-    return
-  }
+app.use('/__reverse/*', (_, res) => {
+  try {
+    fs.readFile(path.join(__dirname, '/__reverse/index.html'), (error, data) => {
+      if (error !== null) {
+        return notFound(res)
+      }
 
-  const upperIndexEntry = fs.lstatSync(path.join(__dirname, upperIndex), { throwIfNoEntry: false })
-  if (upperIndexEntry) {
-    req.url = upperIndex
-    express.static('/__reverse')(req, res, next)
-    return
+      res.statusCode = 200
+      res.setHeader('content-type', 'text/html')
+      res.send(data)
+    })
+  } catch (error) {
+    return notFound(res)
   }
-
-  const baseIndexEntry = fs.lstatSync(path.join(__dirname, baseIndex), { throwIfNoEntry: false })
-  if (baseIndexEntry) {
-    console.log('base')
-    req.url = baseIndex
-    express.static('/__reverse')(req, res, next)
-    return
-  }
-
-  res.statusCode = 404
-  res.setHeader('Content-Type', 'application/json')
-  res.send({ error: 'Not Found', message: `cannot find anything at ${url}`, status: 404 })
 })
 
 app.use('/configurations', (req, res) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,16 +1531,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.10.5, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4":
-  version: 7.21.0
-  resolution: "@babel/runtime@npm:7.21.0"
-  dependencies:
-    regenerator-runtime: ^0.13.11
-  checksum: 7b33e25bfa9e0e1b9e8828bb61b2d32bdd46b41b07ba7cb43319ad08efc6fda8eb89445193e67d6541814627df0ca59122c0ea795e412b99c5183a0540d338ab
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.22.3":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.10.5, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.22.3, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4":
   version: 7.22.3
   resolution: "@babel/runtime@npm:7.22.3"
   dependencies:
@@ -12560,19 +12551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-eslint-parser@npm:^2.0.4":
-  version: 2.2.0
-  resolution: "jsonc-eslint-parser@npm:2.2.0"
-  dependencies:
-    acorn: ^8.5.0
-    eslint-visitor-keys: ^3.0.0
-    espree: ^9.0.0
-    semver: ^7.3.5
-  checksum: aac6509850ba8a893956e00d862d488de9c7f32a352d612f361f43635b3a3426c2ed8b457bdef8188d4ea210b2d7ebcab225caef2d445a92c30cb9be7bb9b8ef
-  languageName: node
-  linkType: hard
-
-"jsonc-eslint-parser@npm:^2.3.0":
+"jsonc-eslint-parser@npm:^2.0.4, jsonc-eslint-parser@npm:^2.3.0":
   version: 2.3.0
   resolution: "jsonc-eslint-parser@npm:2.3.0"
   dependencies:


### PR DESCRIPTION


<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Bugfix

## Description


- routing towards a `parcel` application which is registered as `/app/` takes the precedence when calling the URL `/app`
- public assets on a `parcel` application are served on a path which ends by a trailing slash
- removed `console.log` statements
<!-- 
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->

## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Relevant CHANGELOG (`packages/<package>/CHANGELOG.md`) is updated

## Does this PR introduce a breaking change?

- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->
