### PR TITLE
Feat: support "override" as option for "injectBase" prop on parcel applications

### DIFF
--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typescript set to `^5.0.2` with yarn `3.5.0`
 - Typescript set to `^5.0.4`
 
+### Added
+
+- `micro-lc` json config schema allows to enforce `injectBase` `override` to remove incoming base tags hardcoded on parcel entrypoint
+
 ## [1.0.2] - 2023-01-12
 
 ### Added

--- a/packages/interfaces/schemas/v2/__tests__/test.json
+++ b/packages/interfaces/schemas/v2/__tests__/test.json
@@ -1,6 +1,16 @@
 {
   "$schema": "../config.schema.json",
   "version": 2,
+  "applications": {
+    "parcel": {
+      "integrationMode": "parcel",
+      "route": "/route",
+      "entry": {
+        "html": "index.html",
+        "scripts": ["asd"]
+      }
+    }
+  },
   "importmap": {
     "imports": {
       "a": "/a-1.mjs",

--- a/packages/interfaces/schemas/v2/__tests__/test.json
+++ b/packages/interfaces/schemas/v2/__tests__/test.json
@@ -8,7 +8,19 @@
       "entry": {
         "html": "index.html",
         "scripts": ["asd"]
-      }
+      },
+      "injectBase": "override"
+    },
+    "parcel2": {
+      "integrationMode": "parcel",
+      "route": "/route2",
+      "entry": "index.html",
+      "injectBase": true
+    },
+    "parcel3": {
+      "integrationMode": "parcel",
+      "route": "/route2",
+      "entry": "index.html"
     }
   },
   "importmap": {

--- a/packages/interfaces/schemas/v2/config.schema.json
+++ b/packages/interfaces/schemas/v2/config.schema.json
@@ -235,7 +235,7 @@
           "type": "string"
         },
         {
-          "oneOf": [
+          "anyOf": [
             {
               "type": "object",
               "properties": {

--- a/packages/interfaces/schemas/v2/config.schema.json
+++ b/packages/interfaces/schemas/v2/config.schema.json
@@ -355,8 +355,18 @@
         },
         "injectBase": {
           "description": "Whether to inject a base tag according to the application given route. Can be used when an hash router is not available",
-          "type": "boolean",
-          "default": false
+          "default": false,
+          "oneOf": [
+            {
+              "description": "When true it will attempt to inject a base tag if not already present",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "description": "Injects a base tag removing other base tags",
+              "const": "override"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/interfaces/schemas/v2/index.d.ts
+++ b/packages/interfaces/schemas/v2/index.d.ts
@@ -371,7 +371,7 @@ export interface ParcelApplication {
   /**
    * Whether to inject a base tag according to the application given route. Can be used when an hash router is not available
    */
-  injectBase?: boolean
+  injectBase?: boolean | "override"
 }
 export interface IFrameApplication1 {
   /**
@@ -427,7 +427,7 @@ export interface ParcelApplication1 {
   /**
    * Whether to inject a base tag according to the application given route. Can be used when an hash router is not available
    */
-  injectBase?: boolean
+  injectBase?: boolean | "override"
 }
 /**
  * Global import map
@@ -490,7 +490,7 @@ export interface ParcelApplication2 {
   /**
    * Whether to inject a base tag according to the application given route. Can be used when an hash router is not available
    */
-  injectBase?: boolean
+  injectBase?: boolean | "override"
 }
 /**
  * Orchestrator main page layout DOM configuration

--- a/packages/orchestrator/CHANGELOG.md
+++ b/packages/orchestrator/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `micro-lc` config supports `injectBase` -> `override` const value to instruct the app loader to optionally remove any existing base from an incoming parcel entrypoint
+
 ### Fixes
 
 - security updates / vulnerability fixes in `.docker/Dockerfile` related with `nginx:1.24.0-alpine`

--- a/packages/orchestrator/src/web-component/lib/handler.ts
+++ b/packages/orchestrator/src/web-component/lib/handler.ts
@@ -52,19 +52,22 @@ export const microlcFetch = async (input: RequestInfo | URL, init?: RequestInit,
 
 interface PostProcessTemplateOptions {
   baseURI?: string | undefined
-  injectBase?: boolean
+  injectBase?: boolean | 'override'
   name: string
   url: string
 }
 
 export function postProcessTemplate(tplResult: TemplateResult, opts: PostProcessTemplateOptions): TemplateResult {
-  if (opts.injectBase) {
+  const { injectBase } = opts
+  if (injectBase) {
     const parser = new DOMParser()
     const document = parser.parseFromString(tplResult.template, 'text/html')
     const head = document.querySelector('head')
-    const base = document.querySelector('base')
-    if (base === null) {
+    const bases = head?.querySelectorAll('base')
+
+    if (bases?.length === 0 || injectBase === 'override') {
       const { pathname: route } = new URL(opts.url, opts.baseURI)
+      bases?.forEach((base) => base.remove())
       head?.appendChild(
         Object.assign(document.createElement('base'), {
           href: route,

--- a/packages/orchestrator/src/web-component/lib/update.ts
+++ b/packages/orchestrator/src/web-component/lib/update.ts
@@ -112,7 +112,7 @@ export async function updateGlobalImportMap(importmap: GlobalImportMap): Promise
 export interface ComposableApplicationProperties<T extends BaseExtension = BaseExtension> {
   composerApi: Partial<ComposerApi>
   config: string | PluginConfiguration | undefined
-  injectBase: boolean | undefined
+  injectBase: boolean | 'override' | undefined
   microlcApi: Partial<MicrolcApi<T>>
   schema: SchemaOptions | undefined
 }
@@ -229,7 +229,7 @@ export async function updateApplications<T extends BaseExtension>(this: Microlc<
   const schema = await getApplicationSchema()
 
   pages.reduce((acc, [id, app], idx) => {
-    let injectBase: boolean | undefined = false
+    let injectBase: boolean | 'override' | undefined = false
     let entry: Entry
     let config: string | PluginConfiguration | undefined
     let properties: Record<string, unknown> | undefined

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -80,3 +80,21 @@ test(`
   await page.getByRole('link', { name: 'Go Home' }).click()
   expect(page.url()).toMatch(/\/angular14\/$/)
 })
+
+test(`
+  [override injectBase routing]
+  a parcel application with an existing
+  base tag and marked for injectBase "override"
+  must see its base tag to be removed and a new one to be injected
+  according with the current page location
+`, async ({ page }) => {
+  await goto(page, completeConfig, 'http://localhost:3000/zoned/')
+  await page.waitForFunction(() => window.location.href.endsWith('/zoned/home'))
+  await expect(page.frameLocator('iframe').getByRole('heading', { name: 'Example Domain' })).toBeVisible()
+
+  await page.getByText('Override Base').click()
+
+  await page.waitForFunction(() => window.location.href.endsWith('/zoned/override-base/'))
+  await page.getByText('Go To About Page', { exact: true }).click()
+  await page.waitForFunction(() => window.location.href.endsWith('/zoned/override-base/about'))
+})


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Bugfix
- [x] Feature

## Description

Some parcel applicaations might inject their own `base` tag in the `head` tag. Specifically angular parcels
do it as a default. Previously `micro-lc` allowed to write a custom `base` tag only is none was previously incoming
from the parcel bundle. Thus we add an `injectBase` property value called `override` which instructs `micro-lc` to remove any pre-existing `base` tag and inject the correct one according with the parcel route setting.

<!-- 
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Relevant CHANGELOG (`packages/<package>/CHANGELOG.md`) is updated
- [x]  Documentation was updated or a PR to the [docs](https://github.com/micro-lc/micro-lc.github.io/pulls) is on its way https://github.com/micro-lc/micro-lc.github.io/pull/316

## Does this PR introduce a breaking change?

- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->
