### PR TITLE
iconic: added support to fontawesome free brand icons

### DIFF
--- a/.yarn/versions/0a9785e1.yml
+++ b/.yarn/versions/0a9785e1.yml
@@ -1,0 +1,3 @@
+undecided:
+  - micro-lc
+  - "@micro-lc/layout"

--- a/packages/iconic/CHANGELOG.md
+++ b/packages/iconic/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- support for fontawesome brands icons
+
 ## [1.1.1] - 2023-05-29
 
 ### Fixed

--- a/packages/iconic/index.html
+++ b/packages/iconic/index.html
@@ -17,6 +17,7 @@
 
     function App() {
       const AntdIcon = useIcon('AccountBookFilled', '@ant-design/icons-svg', console.error)
+      const FabIcon = useIcon('faReact', {library: '@fortawesome/free-brands-svg-icons', src: '/dist/fab'}, console.error)
       const FarIcon = useIcon('faAddressBook', {library: '@fortawesome/free-regular-svg-icons', src: '/dist/far'}, console.error)
       const FasIcon = useIcon('faAdd', {library: '@fortawesome/free-solid-svg-icons', src: '/dist/fas'}, console.error)
       return createElement(
@@ -25,6 +26,7 @@
           fallback: React.createElement('div', undefined, 'Loading...')
         },
         createElement(AntdIcon),
+        createElement(FabIcon),
         createElement(FarIcon),
         createElement(FasIcon),
       )

--- a/packages/iconic/package.json
+++ b/packages/iconic/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@ant-design/icons-svg": "^4.2.1",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
+    "@fortawesome/free-brands-svg-icons": "^6.4.0",
     "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",

--- a/packages/iconic/package.json
+++ b/packages/iconic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@micro-lc/iconic",
-  "version": "1.1.1",
+  "version": "1.2.0-rc1",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -54,5 +54,6 @@
   },
   "engines": {
     "node": ">=16.17.0"
-  }
+  },
+  "stableVersion": "1.1.1"
 }

--- a/packages/iconic/scripts/bundle-icons.ts
+++ b/packages/iconic/scripts/bundle-icons.ts
@@ -16,25 +16,28 @@ const reduceToFiles = (globs: string[]) => globs.reduce<string[]>((names, name) 
   return names
 }, [])
 
-type LibKey = 'fas' | 'far'
+type LibKey = 'fab' | 'fas' | 'far'
 
 const mapping: Record<LibKey, string> = {
+  fab: '@fortawesome/free-brands-svg-icons',
   far: '@fortawesome/free-regular-svg-icons',
   fas: '@fortawesome/free-solid-svg-icons',
 }
 
+const __fabDir = dirname(require.resolve('@fortawesome/free-brands-svg-icons'))
 const __fasDir = dirname(require.resolve('@fortawesome/free-solid-svg-icons'))
 const __farDir = dirname(require.resolve('@fortawesome/free-regular-svg-icons'))
+const fab = reduceToFiles(globSync(`${__fabDir}/*.js`))
 const fas = reduceToFiles(globSync(`${__fasDir}/*.js`))
 const far = reduceToFiles(globSync(`${__farDir}/*.js`))
 
-Promise.all(Object.entries({ far, fas }).map(([key, files]) => {
+Promise.all(Object.entries({ fab, far, fas }).map(([key, files]) => {
   const mappingKey = key as LibKey
   console.log(`bundling ${key} folder from icons in ${mapping[mappingKey]}`)
   return build({
     banner: {
       js: `
-        /* Font Awesome Free 6.2.0 by @fontawesome - https://fontawesome.com
+        /* Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com
         License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
         Copyright 2022 Fonticons, Inc.*/
     ` },

--- a/packages/iconic/scripts/list-icons.ts
+++ b/packages/iconic/scripts/list-icons.ts
@@ -25,14 +25,17 @@ const main = async () => {
   const dict: Record<string, LibraryData> = {}
 
   const __antDir = `${dirname(require.resolve('@ant-design/icons-svg'))}/asn`
+  const __fabDir = dirname(require.resolve('@fortawesome/free-brands-svg-icons'))
   const __fasDir = dirname(require.resolve('@fortawesome/free-solid-svg-icons'))
   const __farDir = dirname(require.resolve('@fortawesome/free-regular-svg-icons'))
 
   const antd = reduceToFiles(globSync(`${__antDir}/*.js`)).sort()
+  const fab = reduceToFiles(globSync(`${__fabDir}/*.js`)).filter((iconName) => iconName.startsWith('fa')).sort()
   const fas = reduceToFiles(globSync(`${__fasDir}/*.js`)).filter((iconName) => iconName.startsWith('fa')).sort()
   const far = reduceToFiles(globSync(`${__farDir}/*.js`)).filter((iconName) => iconName.startsWith('fa')).sort()
 
   dict['@ant-design/icons-svg'] = { icons: antd, meta: { name: 'Ant Design' } }
+  dict['@fortawesome/free-brands-svg-icons'] = { icons: fab, meta: { name: 'Font Awesome Brands' } }
   dict['@fortawesome/free-regular-svg-icons'] = { icons: far, meta: { name: 'Font Awesome Regular' } }
   dict['@fortawesome/free-solid-svg-icons'] = { icons: fas, meta: { name: 'Font Awesome Solid' } }
 

--- a/packages/iconic/src/import-icon/index.ts
+++ b/packages/iconic/src/import-icon/index.ts
@@ -17,6 +17,7 @@ import type { IconDefinition as FontawesomeIconDefinition } from '@fortawesome/f
 
 export type Library =
   | '@ant-design/icons-svg'
+  | '@fortawesome/free-brands-svg-icons'
   | '@fortawesome/free-regular-svg-icons'
   | '@fortawesome/free-solid-svg-icons'
 
@@ -47,7 +48,8 @@ interface AntdIconDefaultImport {
 interface FontAwesomeIconImport { default: { definition: FontawesomeIconDefinition } }
 
 const resources: Resources = {
-  '@ant-design/icons-svg': 'https://cdn.jsdelivr.net/npm/@ant-design/icons-svg@latest/es/asn/',
+  '@ant-design/icons-svg': 'https://cdn.jsdelivr.net/npm/@ant-design/icons-svg@4.2.1/es/asn/',
+  '@fortawesome/free-brands-svg-icons': 'https://cdn.jsdelivr.net/npm/@micro-lc/iconic@latest/dist/fab/',
   '@fortawesome/free-regular-svg-icons': 'https://cdn.jsdelivr.net/npm/@micro-lc/iconic@latest/dist/far/',
   '@fortawesome/free-solid-svg-icons': 'https://cdn.jsdelivr.net/npm/@micro-lc/iconic@latest/dist/fas/',
 }
@@ -84,6 +86,7 @@ export async function importIcon(selector: string, resource: ResourceObject): Pr
     return import(uri)
       .then(({ default: { icon } }: { default: AntdIconDefaultImport }) => icon)
       .then((icon) => (typeof icon === 'function' ? icon('currentColor', 'white') : icon))
+  case '@fortawesome/free-brands-svg-icons':
   case '@fortawesome/free-regular-svg-icons':
   case '@fortawesome/free-solid-svg-icons':
     return import(uri).then(({ default: { definition } }: FontAwesomeIconImport) => {

--- a/packages/layout/src/web-components/mlc-layout/mlc-layout.ts
+++ b/packages/layout/src/web-components/mlc-layout/mlc-layout.ts
@@ -38,7 +38,7 @@ export class MlcLayout extends MlcComponent<WrapperProps> {
   private _wasDisconnected = false
 
   @property({ attribute: 'mode' }) mode: Mode = 'overlaySideBar'
-  @property({ attribute: 'enable-dark-mode' }) enableDarkMode = false
+  @property({ attribute: 'enable-dark-mode', type: Boolean }) enableDarkMode = false
   @property({ attribute: false }) logo?: Partial<Logo>
   @property({ attribute: false }) menuItems?: Partial<MenuItem>[]
   @property({ attribute: false }) helpMenu?: Partial<HelpMenu>

--- a/packages/layout/src/web-components/mlc-layout/stories/mlc-layout.stories.ts
+++ b/packages/layout/src/web-components/mlc-layout/stories/mlc-layout.stories.ts
@@ -83,6 +83,7 @@ const menuItems: MlcLayout['menuItems'] = [
   {
     children: [
       {
+        icon: { library: '@fortawesome/free-brands-svg-icons', selector: 'faReact' },
         id: 'application_2',
         label: { en: 'Application 2', it: 'Applicazione 2' },
         type: 'application',

--- a/packages/layout/src/web-components/mlc-layout/types.ts
+++ b/packages/layout/src/web-components/mlc-layout/types.ts
@@ -45,7 +45,7 @@ export type LocalizedText = string | Record<string, string>
 /** Definition of a dynamically loaded icon */
 export interface Icon {
   /** Library from witch the icon is pulled */
-  library: '@ant-design/icons-svg' | '@fortawesome/free-regular-svg-icons' | '@fortawesome/free-solid-svg-icons'
+  library: '@ant-design/icons-svg' | '@fortawesome/free-brands-svg-icons' | '@fortawesome/free-regular-svg-icons' | '@fortawesome/free-solid-svg-icons'
 
   /** Name of the icon according to the chosen library */
   selector: string

--- a/tests/iconic.test.ts
+++ b/tests/iconic.test.ts
@@ -23,6 +23,13 @@ test.describe('iconic react tests', () => {
                 },
                 tag: 'mlc-iconic',
               },
+              {
+                attributes: {
+                  library: '@fortawesome/free-brands-svg-icons',
+                  selector: 'faReact',
+                },
+                tag: 'mlc-iconic',
+              },
             ],
             sources: '/packages/layout/dist/mlc-iconic.js',
           },
@@ -36,6 +43,7 @@ test.describe('iconic react tests', () => {
 
     await expect(page.locator('mlc-iconic').nth(0)).toBeVisible()
     await expect(page.locator('mlc-iconic').nth(1)).toBeVisible()
+    await expect(page.locator('mlc-iconic').nth(2)).toBeVisible()
   })
 
   test('should use react hook to generate an icon', async ({ page, browserName }) => {
@@ -47,6 +55,7 @@ test.describe('iconic react tests', () => {
     await expect(page.locator('svg').nth(0)).toBeVisible()
     await expect(page.locator('svg').nth(1)).toBeVisible()
     await expect(page.locator('svg').nth(2)).toBeVisible()
+    await expect(page.locator('svg').nth(3)).toBeVisible()
   })
 
   test('should render an icon embedded in mlc-iconic custom webcomponent', async ({ page }) => {

--- a/tests/pages/icons.html
+++ b/tests/pages/icons.html
@@ -19,6 +19,7 @@
 
     function App() {
       const AntdIcon = useIcon('AccountBookFilled', '@ant-design/icons-svg', console.error)
+      const FabIcon = useIcon('faReact', {library: '@fortawesome/free-brands-svg-icons', src: '/dist/fab'}, console.error)
       const FarIcon = useIcon('faAddressBook', {library: '@fortawesome/free-regular-svg-icons', src: '/dist/far'}, console.error)
       const FasIcon = useIcon('faAdd', {library: '@fortawesome/free-solid-svg-icons', src: '/dist/fas'}, console.error)
       return createElement(
@@ -27,6 +28,7 @@
           fallback: React.createElement('div', undefined, 'Loading...')
         },
         createElement(AntdIcon),
+        createElement(FabIcon),
         createElement(FarIcon),
         createElement(FasIcon),
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,6 +2089,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fortawesome/free-brands-svg-icons@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@fortawesome/free-brands-svg-icons@npm:6.4.0"
+  dependencies:
+    "@fortawesome/fontawesome-common-types": 6.4.0
+  checksum: 110b22ec366793bc2daa10d0016dfcdf0a0341ced0d8d5c4f68c86e7ffb5e58d3a0b32062e0daaf38af010f85147a9d33e7fd7a8fde79309af7a05254eadbf31
+  languageName: node
+  linkType: hard
+
 "@fortawesome/free-regular-svg-icons@npm:^6.4.0":
   version: 6.4.0
   resolution: "@fortawesome/free-regular-svg-icons@npm:6.4.0"
@@ -2431,6 +2440,7 @@ __metadata:
   dependencies:
     "@ant-design/icons-svg": ^4.2.1
     "@fortawesome/fontawesome-svg-core": ^6.4.0
+    "@fortawesome/free-brands-svg-icons": ^6.4.0
     "@fortawesome/free-regular-svg-icons": ^6.4.0
     "@fortawesome/free-solid-svg-icons": ^6.4.0
     "@fortawesome/react-fontawesome": ^0.2.0


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Feature

## Description

@micro-lc/iconic is going to support dynamic download of icons from @fortawesome/free-brands-svg-icons

## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Relevant CHANGELOG (`packages/iconic/CHANGELOG.md`) is updated
- [x]  Documentation PR to the [docs](https://github.com/micro-lc/micro-lc.github.io/pulls) is on its [way](https://github.com/micro-lc/micro-lc.github.io/pull/329)

## Does this PR introduce a breaking change?

- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
