### PR TITLE
bugfix: no double mount on compose/iframe pages

### DIFF
--- a/packages/orchestrator/CHANGELOG.md
+++ b/packages/orchestrator/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 
 - security updates / vulnerability fixes in `.docker/Dockerfile` related with `nginx:1.24.0-alpine` for `CVE-2023-3138` and `CVE-2023-3316`
+- `compose` are not anymore mounted twice at startup: fixed a race condition between qiankun `loadMicroApp` load and our router `mount` call
 
 ### Versioning
 


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Bugfix

## Description

When a `compose`/`iframe` application is loaded by the router it goes through the following steps:

- if not loaded is loaded by `qiankun`
- previous app is unmounted
- current app is mounted

the load operation by `qiankun` triggers the lifecycle. While this was taken into account for the `bootstrap`
it was not for the `mount` step.

The `mount` step is now executed conditionally when load is not executed (when an app is visited for the second time) `load`.

Unfortunately the app.getStatus() was not updated fast enough by `single-spa` to reflect already on `micro-lc` `mount` call. A `setTimeout` exposed the issue. 

<!-- 
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->

## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Relevant CHANGELOG (`packages/<package>/CHANGELOG.md`) is updated

## Does this PR introduce a breaking change?

- [x] No
