### PR TITLE
[iconic] - Fixed icons children

### DIFF
--- a/packages/iconic/CHANGELOG.md
+++ b/packages/iconic/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - ignore symbols `/* @vite-ignore */` and `/* webpackIgnore: true */` added to dynamic imports to suppress warnings
+- SVG elements different from `svg` and `path` are now correctly rendered
 
 ## [1.3.0] - 2023-07-06
 

--- a/packages/iconic/src/import-icon/index.ts
+++ b/packages/iconic/src/import-icon/index.ts
@@ -35,15 +35,15 @@ export interface IconComponent {
   attrs?: Record<string, unknown>
   children?: IconComponent | IconComponent[]
   key?: number
-  tag: 'svg' | 'path'
+  tag: 'svg' | 'path' | 'rect' | 'circle'
 }
 
-export interface PathComponent extends Omit<IconComponent, 'children'> {
-  tag: 'path'
+export interface ChildComponent extends Omit<IconComponent, 'children'> {
+  tag: 'path' | 'rect' | 'circle'
 }
 
 export interface SvgComponent extends IconComponent {
-  children?: PathComponent | PathComponent[]
+  children?: ChildComponent | ChildComponent[]
   tag: 'svg'
 }
 

--- a/packages/iconic/src/useIcon/index.ts
+++ b/packages/iconic/src/useIcon/index.ts
@@ -25,17 +25,17 @@ import type {
   PropsWithoutRef,
 } from 'react'
 
-import type { ResourceObject, PathComponent, SvgComponent } from '../import-icon'
+import type { ResourceObject, ChildComponent, SvgComponent } from '../import-icon'
 import { importIcon, toArray } from '../import-icon/index.js'
 
 export type SVGProps = ReactSVGProps<HTMLElement>
 
-function iconPathCompose({ attrs }: PathComponent, { key, ref }: PropsWithoutRef<{key: Key}> & RefAttributes<Element>) {
-  return createElement('path', { ...attrs, key, ref })
+function iconChildCompose({ attrs, tag }: ChildComponent, { key, ref }: PropsWithoutRef<{key: Key}> & RefAttributes<Element>) {
+  return createElement(tag, { ...attrs, key, ref })
 }
 
 function iconSvgCompose({ attrs, children = [] }: SvgComponent, { ref, ...props }: SVGProps & RefAttributes<Element>): ReactElement {
-  return createElement('svg', { ...attrs, ...props, ref }, ...toArray(children).map((path, key) => iconPathCompose(path, { key })))
+  return createElement('svg', { ...attrs, ...props, ref }, ...toArray(children).map((child, key) => iconChildCompose(child, { key })))
 }
 
 export function useIcon(


### PR DESCRIPTION
<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Bugfix

## Description

When rendering SVGs, iconic was taking into consideration only elements with the tag `svg` or `path`. This caused other valid tags, like `rect` or `circle` to not be properly visualized. This PR fixed the problem by taking into consideration the actual children tag when creating elements.

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [x] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [x] Relevant CHANGELOG (`packages/<package>/CHANGELOG.md`) is updated

## Does this PR introduce a breaking change?

- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
