### PR TITLE
Fix popStateListener that doesn't propagate history state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- fix window history state propagation in `popStateListener`
+
 ## [2.2.2] - 2023-10-13
 
 ### Fixed

--- a/packages/orchestrator/src/web-component/lib/router.ts
+++ b/packages/orchestrator/src/web-component/lib/router.ts
@@ -444,7 +444,7 @@ function popStateListener<T extends BaseExtension, E extends MicrolcEvent>(this:
   const target = (event.target ?? window) as Window
   const recursiveReroute = reroute
     .bind<(args?: PushArgs) => ReturnType<typeof reroute>>(this)
-  recursiveReroute({ url: target.location.href }).catch(rerouteErrorHandler)
+  recursiveReroute({ url: target.location.href, data: target.history.state }).catch(rerouteErrorHandler)
 }
 
 function domContentLoaded(this: Window, event: Event) {

--- a/packages/orchestrator/src/web-component/lib/router.ts
+++ b/packages/orchestrator/src/web-component/lib/router.ts
@@ -444,7 +444,7 @@ function popStateListener<T extends BaseExtension, E extends MicrolcEvent>(this:
   const target = (event.target ?? window) as Window
   const recursiveReroute = reroute
     .bind<(args?: PushArgs) => ReturnType<typeof reroute>>(this)
-  recursiveReroute({ url: target.location.href, data: target.history.state }).catch(rerouteErrorHandler)
+  recursiveReroute({ data: target.history.state, url: target.location.href }).catch(rerouteErrorHandler)
 }
 
 function domContentLoaded(this: Window, event: Event) {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

There was a bug where calling `window.history.pushState()` with a non-empty state, the state was not passed in the new page.
To fix it, I edited the `popStateListener` function in the `router.ts` to pass the state to the reroute.

## PR Checklist

<!-- TODO: Include update for the CONTRIBUTING file up-to-date regarding information about the commit -->
- [x] The commit message follows our guidelines included in the [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-submit-a-pr)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Relevant CHANGELOG (`packages/<package>/CHANGELOG.md`) is updated

## Does this PR introduce a breaking change?

- [x] No

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->
