### PR TITLE
feat: nginx to v1.25.5

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -13,79 +13,9 @@
 # limitations under the License.
 #
 
-ARG NGINX_VERSION="1.25.1"
-
-###########################################
-# nginx is enhanced with security modules #
-# to generate nonces                      #
-###########################################
-
-FROM nginx:${NGINX_VERSION}-alpine AS builder
-
-ARG NGINX_DEVEL_KIT_VERSION="0.3.2"
-ARG NGINX_SET_MISC_MODULE_VERSION="0.33"
-
-RUN wget "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" && \
-  wget "https://github.com/simpl/ngx_devel_kit/archive/v${NGINX_DEVEL_KIT_VERSION}.tar.gz" -O ngx_devel_kit-${NGINX_DEVEL_KIT_VERSION}.tar.gz && \
-  wget "https://github.com/openresty/set-misc-nginx-module/archive/v${NGINX_SET_MISC_MODULE_VERSION}.tar.gz" -O set-misc-nginx-module-${NGINX_SET_MISC_MODULE_VERSION}.tar.gz;
-
-RUN tar -zxvf nginx-${NGINX_VERSION}.tar.gz
-
-WORKDIR /nginx-${NGINX_VERSION}
-
-RUN tar -xzvf ../ngx_devel_kit-${NGINX_DEVEL_KIT_VERSION}.tar.gz && \
-  tar -xzvf ../set-misc-nginx-module-${NGINX_SET_MISC_MODULE_VERSION}.tar.gz
-
-RUN ls /
-
-RUN apk add --no-cache --virtual .build-deps \
-  gcc \
-  libc-dev \
-  make \
-  openssl-dev \
-  pcre-dev \
-  zlib-dev \
-  linux-headers \
-  curl \
-  gnupg \
-  libxslt-dev \
-  gd-dev \
-  geoip-dev
-
-WORKDIR /nginx-${NGINX_VERSION}
-
-RUN echo `nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p' | grep ssl`
-
-RUN CONFARGS=$(nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p') \
-  CONFARGS=${CONFARGS/-Os -fomit-frame-pointer -g/-Os} && \
-  SET_MISC_DIR="$(pwd)/set-misc-nginx-module-${NGINX_SET_MISC_MODULE_VERSION}" && \
-  DEVEL_KIT_DIR="$(pwd)/ngx_devel_kit-${NGINX_DEVEL_KIT_VERSION}" && \
-  ./configure \
-    --with-compat $CONFARGS \
-    --add-dynamic-module=${DEVEL_KIT_DIR} \
-    --add-dynamic-module=${SET_MISC_DIR} && \
-  make -j2 && \
-  make install
-
-###########################################
-# artifact                                #
-###########################################
-
-ARG NGINX_VERSION
+ARG NGINX_VERSION="1.25.5"
 
 FROM nginx:${NGINX_VERSION}-alpine
-
-# - CVE-2023-2975    Unknown  libcrypto3-3.0.9-r1                      APKG     3.0.9-r2         https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2975
-# - CVE-2023-2975    Unknown  libssl3-3.0.9-r1                         APKG     3.0.9-r2         https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2975
-# - CVE-2023-3138    High     libx11-1.8.4-r0                          APKG     1.8.4-r1         https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3138
-# - CVE-2023-3316    Medium   tiff-4.4.0-r3                            APKG     4.4.0-r4         https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3316
-# - CVE-2023-35945   High     nghttp2-libs-1.51.0-r0                   APKG     1.51.0-r1        https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-35945
-# - CVE-2023-38039   High     curl-8.2.1-r0                            APKG     8.3.0-r0         https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039
-# - CVE-2023-38039   High     libcurl-8.2.1-r0                         APKG     8.3.0-r0         https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039
-RUN apk add --no-cache --upgrade libcrypto3 libssl3 libx11 tiff nghttp2-libs curl libcurl
-
-COPY --from=builder /usr/lib/nginx/modules/ndk_http_module.so /etc/nginx/modules/ndk_http_module.so
-COPY --from=builder /usr/lib/nginx/modules/ngx_http_set_misc_module.so /etc/nginx/modules/ngx_http_set_misc_module.so
 
 ARG COMMIT_SHA
 ARG DESCRIPTION

--- a/.docker/etc/nginx/conf.d/default.conf
+++ b/.docker/etc/nginx/conf.d/default.conf
@@ -45,8 +45,6 @@ http {
     include                           /etc/nginx/cache.d/cache_control.${MODE}.conf;
 
     location ~ (^/|^${BASE_PATH}) {
-      set_secure_random_alphanum      $cspNonce 32;
-
       rewrite                         ^${BASE_PATH}$ /index.html break;
       rewrite                         ^${BASE_PATH}/?(.*) /$1 break;
 
@@ -54,7 +52,7 @@ http {
       sub_filter                      '**MICRO_LC_BASE_PATH**' '${BASE_PATH}';
       sub_filter                      '**MICRO_LC_MODE**' '${MODE}';
       sub_filter                      '**MICRO_LC_CONFIG_SRC**' '${CONFIG_SRC}';
-      sub_filter                      '**CSP_NONCE**' $cspNonce;
+      sub_filter                      '**CSP_NONCE**' $request_id;
 
       expires                         -1;
       try_files                       $uri $uri/index.html /index.html =404;

--- a/.docker/etc/nginx/nginx.conf
+++ b/.docker/etc/nginx/nginx.conf
@@ -13,9 +13,6 @@
 # limitations under the License.
 #
 
-load_module "modules/ndk_http_module.so";
-load_module "modules/ngx_http_set_misc_module.so";
-
 worker_processes 2;
 
 error_log /var/log/nginx/error.log warn;

--- a/packages/orchestrator/CHANGELOG.md
+++ b/packages/orchestrator/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- remove 3rd party modules to generate nonce and bump nginx to v1.25.5
+
 ## [2.4.1] - 2024-04-30
 
 ### Fixed


### PR DESCRIPTION
remove 3rd party modules to generate nonce and bump nginx to v1.25.5

<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type
<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Build related changes
- [x] Versioning

## Description

Nginx used to serve `micro-lc` was using a 3rd party module to create secure random numbers to inject
a CSP nonce into `index.html` file.

This practice is no longer needed while $request_id is enough for the job at hand

<!-- 
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->

## PR Checklist

- [x] Relevant CHANGELOG (`packages/<package>/CHANGELOG.md`) is updated

## Does this PR introduce a breaking change?

- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Use this space to include more information about your pull request. If you don't need to add anything, feel free to remove this section. -->
